### PR TITLE
Increments phase after a vtap lynch (Fixes Stubborn Sun)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 venv/
+env/
 __pycache__/
 config.json
 .vscode

--- a/cogs/admin.py
+++ b/cogs/admin.py
@@ -81,6 +81,7 @@ class Admin(commands.Cog):
                     await game.end(self.bot, winning_faction, individual_wins)
                     break
                 else:
+                    await game.increment_phase(self.bot)
                     # change phase after this.
                     break
 


### PR DESCRIPTION
When a `vtap` resulted in a lynch, the phase wasn't incremented. Due to this, the event loop continued running the day. At the end of the day, it'd print `Nobody was lynched` and begin night.